### PR TITLE
Manual version bumping

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,3 +1,3 @@
 resource_class: small
 docker:
-  - image: cibuilds/base:latest
+  - image: cibuilds/base:2019.10


### PR DESCRIPTION
The latest tag risks that the orb breaks at the beginning of month at any time. In the future bump the versioning manually.