### PR TITLE
Added `sendphoto` command and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,58 @@ jobs:
       - telegram/getme
 ```
 
+### SendGIF
+A command which sends an animated image to the specified Telegram chat.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `telegram-bot-token` | `env_var_name` | TELEGRAM_BOT_TOKEN | Name of environment variable storing your Telegram bot token
+| `telegram-chat-id` | `env_var_name` | TELEGRAM_CHAT_ID | Name of environment variable storing your Telegram chat id
+| `image-url` | `string` | | Enter the image's URL
+
+Example:
+
+```yaml
+version: 2.1
+
+orbs:
+  telegram: woltsu/telegram@x.y.z
+
+jobs:
+  build:
+    docker:
+      - image: <docker image>
+    steps:
+      - telegram/sendgif:
+          - image-url: "https://www.example.com/img.gif"
+```
+
+### SendPhoto
+A command which sends an image to the specified Telegram chat.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `telegram-bot-token` | `env_var_name` | TELEGRAM_BOT_TOKEN | Name of environment variable storing your Telegram bot token
+| `telegram-chat-id` | `env_var_name` | TELEGRAM_CHAT_ID | Name of environment variable storing your Telegram chat id
+| `image-url` | `string` | | Enter the image's URL
+
+Example:
+
+```yaml
+version: 2.1
+
+orbs:
+  telegram: woltsu/telegram@x.y.z
+
+jobs:
+  build:
+    docker:
+      - image: <docker image>
+    steps:
+      - telegram/sendphoto:
+          - image-url: "https://www.example.com/img.jpg"
+```
+
 ## Jobs
 
 ### Notify

--- a/src/commands/sendgif.yml
+++ b/src/commands/sendgif.yml
@@ -23,4 +23,4 @@ steps:
       name: Send Animated Image
       shell: /bin/bash
       command: |
-        if [ ! "$<<parameters.image-url>>" == "" ]; then curl "https://api.telegram.org/bot$<<parameters.telegram-bot-token>>/sendAnimation?chat_id=$<<parameters.telegram-chat-id>>&animation=$<<parameters.image-url>>"; else echo GIF URL invalid; fi
+        if [ ! "$<<parameters.image-url>>" == "" ]; then curl "https://api.telegram.org/bot$<<parameters.telegram-bot-token>>/sendAnimation?chat_id=$<<parameters.telegram-chat-id>>&animation=<<parameters.image-url>>"; else echo GIF URL invalid; fi

--- a/src/commands/sendphoto.yml
+++ b/src/commands/sendphoto.yml
@@ -23,4 +23,4 @@ steps:
       name: Send Image
       shell: /bin/bash
       command: |
-        if [ ! "$<<parameters.image-url>>" == "" ]; then curl "https://api.telegram.org/bot$<<parameters.telegram-bot-token>>/sendPhoto?chat_id=$<<parameters.telegram-chat-id>>&photo=$<<parameters.image-url>>"; else echo Image URL invalid; fi
+        if [ ! "$<<parameters.image-url>>" == "" ]; then curl "https://api.telegram.org/bot$<<parameters.telegram-bot-token>>/sendPhoto?chat_id=$<<parameters.telegram-chat-id>>&photo=<<parameters.image-url>>"; else echo Image URL invalid; fi

--- a/src/commands/sendphoto.yml
+++ b/src/commands/sendphoto.yml
@@ -1,0 +1,26 @@
+description: >
+  Sends an image to the specified Telegram chat.
+parameters:
+  image-url:
+    description: Enter the image's URL.
+    type: string
+    default:
+
+  telegram-bot-token:
+    type: env_var_name
+    default: TELEGRAM_BOT_TOKEN
+    description: >
+      Name of environment variable storing your Telegram bot token
+  telegram-chat-id:
+    type: env_var_name
+    default: TELEGRAM_CHAT_ID
+    description: >
+      Name of environment variable storing your Telegram chat id
+
+steps:
+
+  - run:
+      name: Send Image
+      shell: /bin/bash
+      command: |
+        if [ ! "$<<parameters.image-url>>" == "" ]; then curl "https://api.telegram.org/bot$<<parameters.telegram-bot-token>>/sendPhoto?chat_id=$<<parameters.telegram-chat-id>>&photo=$<<parameters.image-url>>"; else echo Image URL invalid; fi

--- a/src/examples/sendgif.yml
+++ b/src/examples/sendgif.yml
@@ -1,0 +1,20 @@
+description: "Send an animated image to a telegram channel."
+
+usage:
+  version: 2.1
+
+  orbs:
+    telegram: woltsu/telegram@x.y.z
+
+  jobs:
+    build:
+      docker:
+        - image: <docker image>
+      steps:
+        - telegram/sendgif:
+            image-url: "https://www.example.com/img.gif"
+
+  workflows:
+    your-workflow:
+      jobs:
+        - build

--- a/src/examples/sendphoto.yml
+++ b/src/examples/sendphoto.yml
@@ -1,0 +1,20 @@
+description: "Send an image to a telegram channel."
+
+usage:
+  version: 2.1
+
+  orbs:
+    telegram: woltsu/telegram@x.y.z
+
+  jobs:
+    build:
+      docker:
+        - image: <docker image>
+      steps:
+        - telegram/sendphoto:
+            image-url: "https://www.example.com/img.jpg"
+
+  workflows:
+    your-workflow:
+      jobs:
+        - build


### PR DESCRIPTION
Command `sendphoto` added which sends a photo from a URL to a channel.
README.md updated to include `sendgif` and `sendphoto` commands, along
with examples added to `src/examples`.

Closes #23 